### PR TITLE
fix: create pool price error when back to step2

### DIFF
--- a/src/features/Create/ClmmPool/components/SetPriceAndRange.tsx
+++ b/src/features/Create/ClmmPool/components/SetPriceAndRange.tsx
@@ -113,9 +113,9 @@ export default function SetPriceAndRange({
   const onlinePrice =
     tokenBase && tokenQuote && priceBase?.value && priceQuote?.value
       ? new Decimal((priceReverse ? priceBase.value : priceQuote.value) || 0)
-          .div((priceReverse ? priceQuote.value : priceBase.value) || 1)
-          .toDecimalPlaces((priceReverse ? tokenQuote.decimals : tokenBase.decimals) || 6)
-          .toString()
+        .div((priceReverse ? priceQuote.value : priceBase.value) || 1)
+        .toDecimalPlaces((priceReverse ? tokenQuote.decimals : tokenBase.decimals) || 6)
+        .toString()
       : '-- '
 
   const tickPriceRef = useRef<TickData>({})
@@ -136,6 +136,9 @@ export default function SetPriceAndRange({
       }
       switchRef.current = false
       const val = extractNumberOnly(propsVal)
+      if (val === currentPrice) {
+        return
+      }
       setCurrentPrice(val)
       debouncePriceChange({ price: val })
       handleLeftRangeBlur(new Decimal(val || 0).mul(0.5).toString())
@@ -283,12 +286,12 @@ export default function SetPriceAndRange({
               <Text>
                 {isFullRange
                   ? `${formatCurrency(new Decimal(fullRangeTickRef.current.priceLower || 0).toFixed(24), {
-                      maximumDecimalTrailingZeroes: 5,
-                      abbreviated: true
-                    })} - ${formatCurrency(new Decimal(fullRangeTickRef.current.priceUpper || 0).toFixed(24), {
-                      maximumDecimalTrailingZeroes: 5,
-                      abbreviated: true
-                    })}`
+                    maximumDecimalTrailingZeroes: 5,
+                    abbreviated: true
+                  })} - ${formatCurrency(new Decimal(fullRangeTickRef.current.priceUpper || 0).toFixed(24), {
+                    maximumDecimalTrailingZeroes: 5,
+                    abbreviated: true
+                  })}`
                   : `${formatToRawLocaleStr(priceRange[0])} - ${formatToRawLocaleStr(priceRange[1])}`}
               </Text>
               <Text>


### PR DESCRIPTION
1. create pool -> select tokens and fee -> next to step2
4. input initial price (e.g 20), and custom a range (remember to update the min and max value)
5. continue to step3, we can see the amount ratio is 1:53.7
<img width="650" alt="image" src="https://github.com/user-attachments/assets/64823ac0-5171-48dc-94de-5fb31247d564" />

6. back to step2, don't do anything, then continue to step3, input amount, we can see the amount ratio change to 1:32.19
<img width="646" alt="image" src="https://github.com/user-attachments/assets/86ec362b-e20f-4eb9-ae23-624c13b8c163" />
