### PR TITLE
fix: token balance less than actual balance on create position page

### DIFF
--- a/src/features/Clmm/ClmmPosition/CreatePosition.tsx
+++ b/src/features/Clmm/ClmmPosition/CreatePosition.tsx
@@ -111,8 +111,8 @@ export default function CreatePosition() {
 
   const birdeyePoolPrice = hasBirdPrice
     ? new Decimal(birdeyePrice[currentPool!.mintA.address || '']?.value ?? 0).div(
-        birdeyePrice[currentPool!.mintB.address || '']?.value ?? 1
-      )
+      birdeyePrice[currentPool!.mintB.address || '']?.value ?? 1
+    )
     : new Decimal(0)
 
   const tickPriceRef = useRef<{ tickLower?: number; tickUpper?: number; priceLower?: string; priceUpper?: string; liquidity?: BN }>({})
@@ -649,7 +649,6 @@ export default function CreatePosition() {
               onAmountChange={handleAmountChange}
               token1Disable={disabledInput[0]}
               token2Disable={disabledInput[1]}
-              maxMultiplier={0.985}
             />
             <Box border={`1px solid ${colors.backgroundTransparent07}`} bg={colors.backgroundTransparent12} p="4" mt="4" borderRadius="xl">
               <HStack justifyContent="space-between">


### PR DESCRIPTION
### account balance (USDC: 600)
<img width="358" alt="image" src="https://github.com/user-attachments/assets/11901746-e51f-4875-866b-2eb8f096c193" />

### swap page is correct (USDC: 600)
<img width="570" alt="image" src="https://github.com/user-attachments/assets/93766051-4e25-4fb9-ae00-9324a8db3e2f" />


### but the create position page incorrect (USDC: 591)
<img width="701" alt="image" src="https://github.com/user-attachments/assets/bc993ed4-d15e-4352-b734-82b138c3e475" />

